### PR TITLE
Python 2.7 compatibility changes

### DIFF
--- a/pandas_to_postgres/copy_hdf.py
+++ b/pandas_to_postgres/copy_hdf.py
@@ -1,16 +1,6 @@
-from .utilities import (
-    create_file_object,
-    df_generator,
-    logger,
-    cast_pandas,
-    HDFMetadata,
-)
-
+from .utilities import create_file_object, df_generator, logger, cast_pandas
 from ._base_copy import BaseCopy
-from typing import List
 import pandas as pd
-from sqlalchemy.sql.schema import Table
-from sqlalchemy.engine.base import Connection
 
 
 class HDFTableCopy(BaseCopy):
@@ -21,26 +11,33 @@ class HDFTableCopy(BaseCopy):
 
     def __init__(
         self,
-        hdf_tables: List[str],
-        hdf_meta: HDFMetadata,
-        defer_sql_objs: bool = False,
-        conn: Connection = None,
-        table_obj: Table = None,
-        sql_table: str = None,
-        csv_chunksize: int = 10 ** 6,
+        hdf_tables,
+        hdf_meta,
+        defer_sql_objs=False,
+        conn=None,
+        table_obj=None,
+        sql_table=None,
+        csv_chunksize=10 ** 6,
     ):
         """
         Parameters
         ----------
-        hdf_tables: list of HDF keys with data corresponding to destination SQL table
+        hdf_tables: list of strings
+            HDF keys with data corresponding to destination SQL table
             (assumption being that HDF tables:SQL tables is many:one)
-        hdf_meta: HDFMetadata object with information from the store
-        defer_sql_objs: multiprocessing has issue with passing SQLALchemy objects, so if
+        hdf_meta: HDFMetadata object
+            Information from the HDF file for use in building copy objects
+        defer_sql_objs: bool
+            multiprocessing has issue with passing SQLALchemy objects, so if
             True, defer attributing these to the object until after pickled by Pool
-        conn: SQLAlchemy connection managed outside of the object
-        table_obj: SQLAlchemy object for the destination SQL Table
-        sql_table: string of SQL table name
-        csv_chunksize: max rows to keep in memory when generating CSV for COPY
+        conn: SQLAlchemy connection
+            Managed outside of the object
+        table_obj: SQLAlchemy model object
+            Destination SQL Table
+        sql_table: string
+            SQL table name
+        csv_chunksize: int
+            Max rows to keep in memory when generating CSV for COPY
         """
         super().__init__(defer_sql_objs, conn, table_obj, sql_table, csv_chunksize)
 
@@ -89,11 +86,11 @@ class HDFTableCopy(BaseCopy):
         data_formatter_kwargs: list of kwargs to pass to data_formatters functions
         """
         if self.hdf_tables is None:
-            logger.warn(f"No HDF table found for SQL table {self.sql_table}")
+            logger.warn("No HDF table found for SQL table {}".format(self.sql_table))
             return
 
         for hdf_table in self.hdf_tables:
-            logger.info(f"*** {hdf_table} ***")
+            logger.info("*** {} ***".format(hdf_table))
 
             logger.info("Reading HDF table")
             df = pd.read_hdf(self.file_name, key=hdf_table)
@@ -115,7 +112,7 @@ class HDFTableCopy(BaseCopy):
                 self.copy_from_file(fo)
                 del fo
             del df
-        logger.info(f"All chunks copied ({self.rows} rows)")
+        logger.info("All chunks copied ({} rows)".format(self.rows))
 
 
 class SmallHDFTableCopy(HDFTableCopy):
@@ -126,26 +123,33 @@ class SmallHDFTableCopy(HDFTableCopy):
 
     def __init__(
         self,
-        hdf_tables: List[str],
-        hdf_meta: HDFMetadata,
-        defer_sql_objs: bool = False,
-        conn: Connection = None,
-        table_obj: Table = None,
-        sql_table: str = None,
-        csv_chunksize: int = 10 ** 6,
+        hdf_tables,
+        hdf_meta,
+        defer_sql_objs=False,
+        conn=None,
+        table_obj=None,
+        sql_table=None,
+        csv_chunksize=10 ** 6,
     ):
         """
         Parameters
         ----------
-        hdf_tables: list of HDF keys with data corresponding to destination SQL table
+        hdf_tables: list of strings
+            HDF keys with data corresponding to destination SQL table
             (assumption being that HDF tables:SQL tables is many:one)
-        hdf_meta: HDFMetadata object with information from the store
-        defer_sql_objs: multiprocessing has issue with passing SQLALchemy objects, so if
+        hdf_meta: HDFMetadata object
+            Information from the HDF file for use in building copy objects
+        defer_sql_objs: bool
+            multiprocessing has issue with passing SQLALchemy objects, so if
             True, defer attributing these to the object until after pickled by Pool
-        conn: SQLAlchemy connection managed outside of the object
-        table_obj: SQLAlchemy object for the destination SQL Table
-        sql_table: string of SQL table name
-        csv_chunksize: max rows to keep in memory when generating CSV for COPY
+        conn: SQLAlchemy connection
+            Managed outside of the object
+        table_obj: SQLAlchemy model object
+            Destination SQL Table
+        sql_table: string
+            SQL table name
+        csv_chunksize: int
+            Max rows to keep in memory when generating CSV for COPY
         """
         super().__init__(
             hdf_tables,
@@ -172,7 +176,7 @@ class SmallHDFTableCopy(HDFTableCopy):
             return
 
         for hdf_table in self.hdf_tables:
-            logger.info(f"*** {hdf_table} ***")
+            logger.info("*** {} ***".format(hdf_table))
             logger.info("Reading HDF table")
             df = pd.read_hdf(self.file_name, key=hdf_table)
             self.rows += len(df)
@@ -190,7 +194,7 @@ class SmallHDFTableCopy(HDFTableCopy):
             self.copy_from_file(fo)
             del df
             del fo
-        logger.info(f"All chunks copied ({self.rows} rows)")
+        logger.info("All chunks copied ({} rows)".format(self.rows))
 
 
 class BigHDFTableCopy(HDFTableCopy):
@@ -204,26 +208,33 @@ class BigHDFTableCopy(HDFTableCopy):
 
     def __init__(
         self,
-        hdf_tables: List[str],
-        hdf_meta: HDFMetadata,
-        defer_sql_objs: bool = False,
-        conn: Connection = None,
-        table_obj: Table = None,
-        sql_table: str = None,
-        csv_chunksize: int = 10 ** 6,
+        hdf_tables,
+        hdf_meta,
+        defer_sql_objs=False,
+        conn=None,
+        table_obj=None,
+        sql_table=None,
+        csv_chunksize=10 ** 6,
     ):
         """
         Parameters
         ----------
-        hdf_tables: list of HDF keys with data corresponding to destination SQL table
+        hdf_tables: list of strings
+            HDF keys with data corresponding to destination SQL table
             (assumption being that HDF tables:SQL tables is many:one)
-        hdf_meta: HDFMetadata object with information from the store
-        defer_sql_objs: multiprocessing has issue with passing SQLALchemy objects, so if
+        hdf_meta: HDFMetadata object
+            Information from the HDF file for use in building copy objects
+        defer_sql_objs: bool
+            multiprocessing has issue with passing SQLALchemy objects, so if
             True, defer attributing these to the object until after pickled by Pool
-        conn: SQLAlchemy connection managed outside of the object
-        table_obj: SQLAlchemy object for the destination SQL Table
-        sql_table: string of SQL table name
-        csv_chunksize: max rows to keep in memory when generating CSV for COPY
+        conn: SQLAlchemy connection
+            Managed outside of the object
+        table_obj: SQLAlchemy model object
+            Destination SQL Table
+        sql_table: string
+            SQL table name
+        csv_chunksize: int
+            Max rows to keep in memory when generating CSV for COPY
         """
         super().__init__(
             hdf_tables,
@@ -246,11 +257,11 @@ class BigHDFTableCopy(HDFTableCopy):
         data_formatter_kwargs: list of kwargs to pass to data_formatters functions
         """
         if self.hdf_tables is None:
-            logger.warn(f"No HDF table found for SQL table {self.sql_table}")
+            logger.warn("No HDF table found for SQL table {}".format(self.sql_table))
             return
 
         for hdf_table in self.hdf_tables:
-            logger.info(f"*** {hdf_table} ***")
+            logger.info("*** {} ***".format(hdf_table))
 
             with pd.HDFStore(self.file_name) as store:
                 nrows = store.get_storer(hdf_table).nrows
@@ -264,7 +275,7 @@ class BigHDFTableCopy(HDFTableCopy):
             start = 0
 
             for i in range(n_chunks):
-                logger.info(f"*** HDF chunk {i + 1} of {n_chunks} ***")
+                logger.info("*** HDF chunk {i + 1} of {} ***".format(n_chunks))
                 logger.info("Reading HDF table")
                 stop = min(start + self.hdf_chunksize, nrows)
                 df = pd.read_hdf(self.file_name, key=hdf_table, start=start, stop=stop)
@@ -286,4 +297,4 @@ class BigHDFTableCopy(HDFTableCopy):
                     self.copy_from_file(fo)
                     del fo
                 del df
-        logger.info(f"All chunks copied ({self.rows} rows)")
+        logger.info("All chunks copied ({} rows)".format(self.rows))

--- a/pandas_to_postgres/hdf_to_postgres.py
+++ b/pandas_to_postgres/hdf_to_postgres.py
@@ -1,10 +1,23 @@
-from typing import List
 from multiprocessing import Pool
-import SQLAlchemy
-from pandas_to_postgres import HDFTableCopy, HDFMetadata
+from .copy_hdf import HDFTableCopy, HDFMetadata
 
 
 def create_hdf_table_objects(hdf_meta, csv_chunksize=10 ** 6):
+    """
+    Create list of HDFTableCopy objects to iterate to run the copy method on each
+
+    Parameters
+    ----------
+    hdf_meta: HDFMetadata
+        Object built from HDF metadata to reference in each copier
+    csv_chunksize: int
+        Maximum number of rows to store in an in-memory StringIO CSV
+
+    Returns
+    -------
+    tables: list
+        List of HDFTableCopy objects
+    """
     tables = []
 
     for sql_table, hdf_tables in hdf_meta.sql_to_hdf.items():
@@ -21,32 +34,47 @@ def create_hdf_table_objects(hdf_meta, csv_chunksize=10 ** 6):
     return tables
 
 
-def copy_worker(db: SQLAlchemy, copy_obj: HDFTableCopy, defer_sql_objs: bool = True):
-    db.engine.dispose()
-    with db.engine.connect() as conn:
+def _copy_worker(copy_obj, defer_sql_objs=True):
+    """
+    Handle a SQLAlchemy connection and copy using HDFTableCopy object
+
+    copy_obj: HDFTableCopy or subclass
+        Object to use to run the copy() method on
+    defer_sql_objs: bool
+        If True, SQL objects were not build upon instantiation of copy_obj and should
+        be built before copying data to db (needed for multiprocessing)
+    """
+    database.engine.dispose()
+    with database.engine.connect() as conn:
         conn.execution_options(autocommit=True)
         conn.execute("SET maintenance_work_mem TO 1000000;")
 
         if defer_sql_objs:
-            table_obj = db.metadata.tables[copy_obj.sql_table]
+            table_obj = database.metadata.tables[copy_obj.sql_table]
             copy_obj.instantiate_sql_objs(conn, table_obj)
 
         copy_obj.copy()
 
 
-def hdf_to_postgres(
-    file_name: str, db: SQLAlchemy, keys: List[str] = [], csv_chunksize: int = 10 ** 6
-):
+def hdf_to_postgres(file_name, db, keys=[], csv_chunksize=10 ** 6):
     """
     Copy tables in a HDF file to PostgreSQL database
 
     Parameters
     ----------
-    file_name: name of file or path to file of HDF to use to copy
-    db: SQLAlchemy object of destination database
-    keys: list of HDF keys to copy
-    csv_chunksize: maximum number of StringIO CSV rows to keep in memory at a time
+    file_name: str
+        name of file or path to file of HDF to use to copy
+    db: SQLAlchemy database object
+        destination database
+    keys: list of strings
+        HDF keys to copy
+    csv_chunksize: int
+        Maximum number of StringIO CSV rows to keep in memory at a time
     """
+
+    global database
+    database = db
+
     hdf = HDFMetadata(
         file_name, keys, metadata_attr="atlas_metadata", metadata_keys=["levels"]
     )
@@ -54,27 +82,31 @@ def hdf_to_postgres(
     tables = create_hdf_table_objects(hdf, csv_chunksize=csv_chunksize)
 
     for table in tables:
-        copy_worker(table, defer_sql_objs=True)
+        _copy_worker(table, defer_sql_objs=True)
 
 
 def multiprocess_hdf_to_postgres(
-    file_name: str,
-    db: SQLAlchemy,
-    keys: List[str] = [],
-    processes: int = 4,
-    csv_chunksize: int = 10 ** 6,
+    file_name, db, keys=[], processes=4, csv_chunksize=10 ** 6
 ):
     """
     Copy tables in a HDF file to PostgreSQL database using a multiprocessing Pool
 
     Parameters
     ----------
-    file_name: name of file or path to file of HDF to use to copy
-    db: SQLAlchemy object of destination database
-    keys: list of HDF keys to copy
-    processes: number of processes in the Pool
-    csv_chunksize: maximum number of StringIO CSV rows to keep in memory at a time
+    file_name: str
+        Name of file or path to file of HDF to use to copy
+    db: SQLAlchemy object
+        Destination database
+    keys: list of strings
+        HDF keys to copy
+    processes: int
+        Number of processes in the Pool
+    csv_chunksize: int
+        Maximum number of StringIO CSV rows to keep in memory at a time
     """
+
+    global database
+    database = db
 
     hdf = HDFMetadata(
         file_name, keys, metadata_attr="atlas_metadata", metadata_keys=["levels"]
@@ -84,7 +116,7 @@ def multiprocess_hdf_to_postgres(
 
     try:
         p = Pool(processes)
-        p.map(copy_worker, tables, chunksize=1)
+        p.map(_copy_worker, tables, chunksize=1)
     finally:
         del tables
         del hdf

--- a/pandas_to_postgres/utilities.py
+++ b/pandas_to_postgres/utilities.py
@@ -1,6 +1,5 @@
 import logging
-from typing import List
-from pandas import DataFrame, HDFStore, isna
+from pandas import HDFStore, isna
 from collections import defaultdict
 from io import StringIO
 
@@ -19,11 +18,11 @@ class HDFMetadata(object):
 
     def __init__(
         self,
-        file_name: str,
-        keys: List[str] = None,
-        chunksize: int = 10 ** 7,
-        metadata_attr: str = None,
-        metadata_keys: List[str] = [],
+        file_name,
+        keys=None,
+        chunksize=10 ** 7,
+        metadata_attr=None,
+        metadata_keys=[],
     ):
         self.file_name = file_name
         self.chunksize = chunksize
@@ -32,12 +31,17 @@ class HDFMetadata(object):
         """
         Parameters
         ----------
-        file_name: path to hdf file to copy from
-        keys: list of hdf keys to copy data from
-        chunksize: maximum rows read from an hdf file into a pandas dataframe when using
+        file_name: str
+            path to hdf file to copy from
+        keys: list of strings
+            HDF keys to copy data from
+        chunksize: int
+            Maximum rows read from an hdf file into a pandas dataframe when using
             the BigTable protocol
-        metadata_attr: location of relevant metadata in store.get_storer().attrs
-        metadata_keys: list of keys to get from metadata store
+        metadata_attr: str
+            :ocation of relevant metadata in store.get_storer().attrs
+        metadata_keys: list of strings
+            Keys to get from metadata store
         """
 
         with HDFStore(self.file_name, mode="r") as store:
@@ -47,10 +51,12 @@ class HDFMetadata(object):
                 for key in self.keys:
                     try:
                         metadata = store.get_storer(key).attrs[metadata_attr]
-                        logger.info(f"{key} metadata: {metadata}")
+                        logger.info("Metadata: {}".format(metadata))
                     except (AttributeError, KeyError):
                         if "/meta" not in key:
-                            logger.info(f"No metadata found for key '{key}'. Skipping")
+                            logger.info(
+                                "No metadata found for key '{}'. Skipping".format(key)
+                            )
                         continue
 
                     for mkey in metadata_keys:
@@ -61,13 +67,21 @@ class HDFMetadata(object):
                     if sql_table:
                         self.sql_to_hdf[sql_table].add(key)
                     else:
-                        logger.warn(f"No SQL table name found for {key}")
+                        logger.warn("No SQL table name found for {}".format(key))
 
 
-def create_file_object(df: DataFrame) -> StringIO:
+def create_file_object(df):
     """
     Writes pandas dataframe to an in-memory StringIO file object. Adapted from
     https://gist.github.com/mangecoeur/1fbd63d4758c2ba0c470#gistcomment-2086007
+
+    Parameters
+    ----------
+    df: pandas DataFrame
+
+    Returns
+    -------
+    file_object: StringIO
     """
     file_object = StringIO()
     df.to_csv(file_object, index=False)
@@ -75,14 +89,16 @@ def create_file_object(df: DataFrame) -> StringIO:
     return file_object
 
 
-def df_generator(df: DataFrame, chunksize: int = 10 ** 6):
+def df_generator(df, chunksize=10 ** 6):
     """
     Create a generator to iterate over chunks of a dataframe
 
     Parameters
     ----------
-    df: pandas dataframe to iterate over
-    chunksize: max number of rows to return in a chunk
+    df: pandas dataframe
+        Data to iterate over
+    chunksize: int
+        Max number of rows to return in a chunk
     """
     rows = 0
     if not df.shape[0] % chunksize:
@@ -91,14 +107,12 @@ def df_generator(df: DataFrame, chunksize: int = 10 ** 6):
         n_chunks = (df.shape[0] // chunksize) + 1
 
     for i in range(n_chunks):
-        logger.info(f"Chunk {i + 1}/{n_chunks}")
+        logger.info("Chunk {i}/{n}".format(i=i + 1, n=n_chunks))
         yield df.iloc[rows : rows + chunksize]
         rows += chunksize
 
 
-def cast_pandas(
-    df: DataFrame, columns: list = None, copy_obj: object = None, **kwargs
-) -> DataFrame:
+def cast_pandas(df, columns=None, copy_obj=None, **kwargs):
     """
     Pandas does not handle null values in integer or boolean fields out of the
     box, so cast fields that should be these types in the database to object
@@ -106,17 +120,19 @@ def cast_pandas(
 
     Parameters
     ----------
-    df: data frame with fields that are desired to be int or bool as float with
+    df: pandas DataFrame
+        data frame with fields that are desired to be int or bool as float with
         np.nan that should correspond to None
-
-    columns: list of SQLAlchemy Columns to iterate through to determine data types
-
-    copy_obj: instance of BaseCopy passed from the BaseCopy.data_formatting method where
+    columns: list of SQLAlchemy Columns
+        Columnsto iterate through to determine data types
+    copy_obj: BaseCopy or subclass
+        instance of BaseCopy passed from the BaseCopy.data_formatting method where
         we can access BaseCopy.table_obj.columns
 
     Returns
     -------
-    df: dataframe with fields that correspond to Postgres int, bigint, and bool
+    df: pandas DataFrame
+        DataFrame with fields that correspond to Postgres int, bigint, and bool
         fields changed to objects with None values for null
     """
 


### PR DESCRIPTION
Take out the known obstacles for 2.7 usage (Issue #2). Removes f-strings and type hinting and added type hints to docstrings